### PR TITLE
feat(demo-api): add ChatOptions to createChatMessage API

### DIFF
--- a/demo/api/model/src/main/smithy/chat/chat-messages.smithy
+++ b/demo/api/model/src/main/smithy/chat/chat-messages.smithy
@@ -41,6 +41,21 @@ structure ChatEngineConfig {
     condense_question_prompt: String
 }
 
+/// Chat search options
+structure ChatSearchOptions {
+    // The number of sources to consider (k).
+    limit: Integer
+    // Key-value parameter to pass for filtering metadata (e.g.: domain, collection, etc.).
+    filters: StringAnyMap
+}
+
+structure ChatOptions {
+    // Agent domain.
+    domain: String
+    // Search options for vectorstore.
+    search: ChatSearchOptions
+}
+
 @mixin
 structure ChatMessageIdMixin with [ChatIdMixin] {
     @required
@@ -107,6 +122,10 @@ structure CreateChatMessageInput for CreateChatMessage {
     // Config for chat available only to authorized admin-like groups
     // Will be ignored for other users
     config: ChatEngineConfig
+
+    // Define chat options such as domain, and search options for filtering
+    // available for all users
+    options: ChatOptions
 }
 
 structure CreateChatMessageOutput for CreateChatMessage {

--- a/demo/api/model/src/main/smithy/types.smithy
+++ b/demo/api/model/src/main/smithy/types.smithy
@@ -145,3 +145,9 @@ structure Tag {
 list Tags {
     member: Tag
 }
+
+/// A generic structure for maps that are indexed by a string and hold Any value
+map StringAnyMap {
+    key: String
+    value: Any
+}

--- a/demo/infra/src/application/ai/inference-engine/handler/index.ts
+++ b/demo/infra/src/application/ai/inference-engine/handler/index.ts
@@ -33,6 +33,7 @@ export const handler = createChatMessageHandler(
 
     const question = input.body.question;
     const chatId = input.requestParameters.chatId;
+    const chatOptions = input.body.options;
 
     let config: Chat.ChatEngineConfig = {};
     if (isAdmin(callingIdentity) && input.body.config) {
@@ -58,7 +59,7 @@ export const handler = createChatMessageHandler(
       config,
       chatHistoryTable: ENV.CHAT_MESSAGE_TABLE_NAME,
       chatHistoryTableIndexName: ENV.CHAT_MESSAGE_TABLE_GSI_INDEX_NAME,
-      domain: ENV.DOMAIN,
+      domain: chatOptions?.domain ?? ENV.DOMAIN,
       search: {
         url: ENV.SEARCH_URL,
         fetch: createSignedFetcher({
@@ -67,6 +68,10 @@ export const handler = createChatMessageHandler(
           region: process.env.AWS_REGION! || process.env.AWS_DEFAULT_REGION!,
           idToken: callingIdentity.idToken,
         }),
+        k: chatOptions?.search?.limit,
+        filter: {
+          ...chatOptions?.search?.filters,
+        },
       },
       verbose: true,
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* add ChatOptions and ChatSearchOptions to CreateChatMessage API
* wired up in inference-handler

This will help to handle multiple domains within a deployment and to pass filter parameters from the website.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
