### PR TITLE
fix(demo-website): sources not shown after refresh/new load

### DIFF
--- a/demo/website/src/hooks/chats.ts
+++ b/demo/website/src/hooks/chats.ts
@@ -320,8 +320,13 @@ export function useMessageSources(
   return useListChatMessageSources(
     { chatId, messageId },
     {
-      // @ts-expect-error
-      select: (data) => data.chatMessageSources || ([] as ChatMessageSource[]),
+      select: (data) => {
+        if (data.pages && data.pages.length > 0) {
+          return data.pages.flatMap((page) => page.chatMessageSources);
+        }
+        // @ts-ignore
+        return data.chatMessageSources || ([] as ChatMessageSource[]);
+      },
     }
   );
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When refreshing/newly loading chats, `Sources` button shows emply modal. With this fix, `Sources` modal will show all related sources related to a chat

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
