### PR TITLE
fix: remove JDK 17 hard requirement and break circular build dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@ Galileo is:
 | Poetry                | >=1.5,<2    | https://python-poetry.org/docs/ |
 | AWS CLI               | v2          | https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html |
 | Docker<sup>1</sup>    | v20+        | https://docs.docker.com/desktop/ |
-| JDK                   | v17<sup>2</sup> | [Amazon Corretto 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html) |
+| JDK                   | v17+        | [Amazon Corretto 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html) |
 
 > <sup>1</sup> Docker virtual disk space should have at least 30GB of free space. If you see `no space left on device` error during build, free up space by running `docker system prune -f` and/or increasing the virtual disk size.
->
-> <sup>2</sup> At this time higher versions of JDK are not supported
 
 *AWS Service Quotas:*
 > Ensure the following service quota limits are increased before deploying. The deployment performs a check and will fail early if limits are not met.

--- a/bin/galileo-cli.ts
+++ b/bin/galileo-cli.ts
@@ -17,7 +17,8 @@ import {
   DEFAULT_PREDEFINED_FOUNDATION_MODEL_LIST,
   FoundationModelIds,
 } from "../demo/infra/src/application/ai/foundation-models/ids";
-import { BEDROCK_DEFAULT_MODEL, BEDROCK_REGION, BedrockModel, BedrockModelIds } from '../demo/infra/src/galileo/ai/llms/framework/bedrock';
+import { BedrockModelIds, BEDROCK_DEFAULT_MODEL, BEDROCK_REGION } from '../demo/infra/src/galileo/ai/llms/framework/bedrock/ids';
+import { formatBedrockModelUUID } from '../demo/infra/src/galileo/ai/llms/framework/bedrock/utils';
 
 const ROOT = path.resolve(__dirname, "..");
 
@@ -282,7 +283,7 @@ type Task = Parameters<typeof execa.execaCommand>;
 
   const availableModelIds = includesBedrock ? [
     ...(foundationModels as string[]).filter(v => v !== FoundationModelIds.BEDROCK),
-    ...(bedrockModelIds as string[]).map(BedrockModel.formatUUID),
+    ...(bedrockModelIds as string[]).map(formatBedrockModelUUID),
   ] : (foundationModels as string[]);
 
   const { deployModels, defaultModelId } = cached(

--- a/demo/api/generated/runtime/python/README.md
+++ b/demo/api/generated/runtime/python/README.md
@@ -105,6 +105,8 @@ Class | Method | HTTP request | Description
  - [ChatEngineConfigSearchType](docs/ChatEngineConfigSearchType.md)
  - [ChatMessage](docs/ChatMessage.md)
  - [ChatMessageSource](docs/ChatMessageSource.md)
+ - [ChatOptions](docs/ChatOptions.md)
+ - [ChatSearchOptions](docs/ChatSearchOptions.md)
  - [ClientErrorResponseContent](docs/ClientErrorResponseContent.md)
  - [CreateChatMessageRequestContent](docs/CreateChatMessageRequestContent.md)
  - [CreateChatMessageResponseContent](docs/CreateChatMessageResponseContent.md)
@@ -128,6 +130,7 @@ Class | Method | HTTP request | Description
  - [ServerTemporaryErrorResponseContent](docs/ServerTemporaryErrorResponseContent.md)
  - [SimilaritySearchRequestContent](docs/SimilaritySearchRequestContent.md)
  - [SimilaritySearchResponseContent](docs/SimilaritySearchResponseContent.md)
+ - [StringAnyMap](docs/StringAnyMap.md)
  - [UpdateChatRequestContent](docs/UpdateChatRequestContent.md)
  - [UpdateChatResponseContent](docs/UpdateChatResponseContent.md)
 

--- a/demo/infra/src/galileo/ai/llms/framework/bedrock/ids.ts
+++ b/demo/infra/src/galileo/ai/llms/framework/bedrock/ids.ts
@@ -1,0 +1,28 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+PDX-License-Identifier: Apache-2.0 */
+
+/**
+ * NOTE: these constants are stored separately from other BedrockModel
+ *       types so that they can be used by our galileo-cli script without
+ *       depending on the base types defined in galileo-sdk; they should
+ *       be moved back into index.ts when they are migrated into galileo-sdk
+ */
+export enum BedrockModelIds {
+  TITAN_TEXT_LARGE = "amazon.titan-tg1-large",
+  TITAN_TEXT_XL = "amazon.titan-tg1-xlarge",
+  // TITAN_TEXT_EMBEDDINGS = "amazon.titan-e1t-medium", // NB: Embedding model not supported with current I/O of inference flow
+
+  ANTHROPIC_CLAUDE_V2 = "anthropic.claude-v2",
+  ANTHROPIC_CLAUDE_V2_100k = "anthropic.claude-v2-100k",
+  ANTHROPIC_CLAUDE_V1 = "anthropic.claude-v1",
+  ANTHROPIC_CLAUDE_V1_INSTANT = "anthropic.claude-instant-v1",
+  ANTHROPIC_CLAUDE_V1_100K = "anthropic.claude-v1-100k",
+
+  AI21_JURASSIC_MID = "ai21.j2-mid",
+  AI21_JURASSIC_ULTRA = "ai21.j2-ultra",
+  AI21_JURASSIC_JUMBO_INSTRUCT = "ai21.j2-jumbo-instruct",
+  AI21_JURASSIC_GRANDE_INSTRUCT = "ai21.j2-grande-instruct",
+}
+
+export const BEDROCK_REGION = "us-east-1";
+export const BEDROCK_DEFAULT_MODEL = BedrockModelIds.TITAN_TEXT_LARGE;

--- a/demo/infra/src/galileo/ai/llms/framework/bedrock/index.ts
+++ b/demo/infra/src/galileo/ai/llms/framework/bedrock/index.ts
@@ -9,27 +9,10 @@ import {
   ModelFramework,
 } from "@aws-galileo/galileo-sdk/lib/models";
 import { Construct, IConstruct } from "constructs";
+import { BEDROCK_REGION } from "./ids";
+import { formatBedrockModelUUID } from "./utils";
 
-export const BEDROCK_REGION = "us-east-1";
-
-export enum BedrockModelIds {
-  TITAN_TEXT_LARGE = "amazon.titan-tg1-large",
-  TITAN_TEXT_XL = "amazon.titan-tg1-xlarge",
-  // TITAN_TEXT_EMBEDDINGS = "amazon.titan-e1t-medium", // NB: Embedding model not supported with current I/O of inference flow
-
-  ANTHROPIC_CLAUDE_V2 = "anthropic.claude-v2",
-  ANTHROPIC_CLAUDE_V2_100k = "anthropic.claude-v2-100k",
-  ANTHROPIC_CLAUDE_V1 = "anthropic.claude-v1",
-  ANTHROPIC_CLAUDE_V1_INSTANT = "anthropic.claude-instant-v1",
-  ANTHROPIC_CLAUDE_V1_100K = "anthropic.claude-v1-100k",
-
-  AI21_JURASSIC_MID = "ai21.j2-mid",
-  AI21_JURASSIC_ULTRA = "ai21.j2-ultra",
-  AI21_JURASSIC_JUMBO_INSTRUCT = "ai21.j2-jumbo-instruct",
-  AI21_JURASSIC_GRANDE_INSTRUCT = "ai21.j2-grande-instruct",
-}
-
-export const BEDROCK_DEFAULT_MODEL = BedrockModelIds.TITAN_TEXT_LARGE;
+export * from "./ids";
 
 export interface BedrockModelProps {
   /**
@@ -83,9 +66,7 @@ export interface BedrockModelProps {
  * with the rest of the application at runtime.
  */
 export class BedrockModel extends Construct implements IModelInfoProvider {
-  static formatUUID(modelId: string): string {
-    return `bedrock::${modelId}`;
-  }
+  static formatUUID = formatBedrockModelUUID;
 
   readonly modelInfo: IModelInfo;
 

--- a/demo/infra/src/galileo/ai/llms/framework/bedrock/utils.ts
+++ b/demo/infra/src/galileo/ai/llms/framework/bedrock/utils.ts
@@ -1,0 +1,16 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+PDX-License-Identifier: Apache-2.0 */
+
+/**
+ * NOTE: this utility is defined separately from other BedrockModel
+ *       types so that it can be used by our galileo-cli script without
+ *       depending on the base types defined in galileo-sdk; it should
+ *       be moved back into index.ts when it is migrated into galileo-sdk
+ */
+
+/**
+ * Generates a forrmated UUID string of given Bedrock model id
+ */
+export function formatBedrockModelUUID(modelId: string): string {
+  return `bedrock::${modelId}`;
+}

--- a/prerequisite-check.sh
+++ b/prerequisite-check.sh
@@ -73,7 +73,7 @@ check "docker" "docker --version" ">=20.10" \
   "Recommendation: Use Docker Desktop to install Docker 20+. See https://docs.docker.com/desktop/"
 DOCKER_PASS=$?
 
-check "java" "java --version | head -n 1" "17" \
+check "java" "java --version | head -n 1" ">=17" \
   "Recommendation: Use Amazon Corretto 17. See https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html"
 JAVA_PASS=$?
 


### PR DESCRIPTION
- recent PDK update means JDK 17+ is supported
- decouble some basic Bedrock related IDs until that is moved in galileo-sdk

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
