### PR TITLE
chore(workflow): disable release_docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    if: needs.release.outputs.latest_commit == github.sha
+    if: ${{ false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,5 +100,4 @@ jobs:
           path: ./docs/dist/docs
       - name: Deploy to GitHub Pages
         id: deployment
-        if: ${{ false }}
         uses: actions/deploy-pages@v2

--- a/projenrc/monorepo.ts
+++ b/projenrc/monorepo.ts
@@ -270,7 +270,8 @@ export class MonorepoProject extends MonorepoTsProject {
       },
       runsOn: ["ubuntu-latest"],
       needs: ["release", "release_github"],
-      if: "needs.release.outputs.latest_commit == github.sha",
+      if: "${{ false }}", // disable until repo is public, since all pages are public
+      // if: "needs.release.outputs.latest_commit == github.sha",
       permissions: {
         contents: JobPermission.WRITE,
         pages: JobPermission.WRITE,
@@ -314,7 +315,6 @@ export class MonorepoProject extends MonorepoTsProject {
           name: "Deploy to GitHub Pages",
           id: "deployment",
           uses: "actions/deploy-pages@v2",
-          if: "${{ false }}", // disable until repo is public, since all pages are public
         },
       ],
     };


### PR DESCRIPTION
Needs to be disabled at root of the job to prevent `Error: Get Pages site failed. `


