### PR TITLE
fix(bedrock): handle model kwargs correctly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,25 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
+      "name": "Galileo SDK - Bedrock Integ",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "--nolazy",
+        "${workspaceRoot}/packages/galileo-sdk/node_modules/jest/bin/jest.js",
+        "--runInBand",
+        "--collectCoverage=false",
+        "--colors",
+        "--verbose",
+        "--testTimeout=100000000",
+        "--testMatch=*/**/bedrock.integ.ts",
+      ],
+      "cwd": "${workspaceFolder}/packages/galileo-sdk",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
       "name": "Galileo Interceptors - Debug Jest",
       "type": "node",
       "request": "launch",

--- a/packages/galileo-sdk/package.json
+++ b/packages/galileo-sdk/package.json
@@ -332,6 +332,11 @@
       "import": "./lib/prompt/templates/chat/question-answer.js",
       "require": "./lib/prompt/templates/chat/question-answer.cjs"
     },
+    "./lib/utils/bedrock": {
+      "types": "./lib/utils/bedrock.d.ts",
+      "import": "./lib/utils/bedrock.js",
+      "require": "./lib/utils/bedrock.cjs"
+    },
     "./lib/vectorstores": {
       "types": "./lib/vectorstores/index.d.ts",
       "import": "./lib/vectorstores/index.js",

--- a/packages/galileo-sdk/src/chat/context.ts
+++ b/packages/galileo-sdk/src/chat/context.ts
@@ -11,6 +11,7 @@ import { resolveFoundationModelCredentials } from '../models/cross-account.js';
 import { FoundationModelInventory } from '../models/index.js';
 import { IModelInfo, Kwargs, isBedrockFramework, isSageMakerEndpointFramework } from '../models/types.js';
 import { ChatCondenseQuestionPromptRuntime, ChatCondenseQuestionPromptTemplate, ChatQuestionAnswerPromptRuntime, ChatQuestionAnswerPromptTemplate } from '../prompt/templates/chat/index.js';
+import { omitManagedBedrockKwargs } from '../utils/bedrock.js';
 
 const logger = getLogger('chat/adapter');
 
@@ -123,12 +124,14 @@ export class ChatEngineContext {
     } else if (isBedrockFramework(modelInfo.framework)) {
       const { modelId, region, role, endpointUrl } = modelInfo.framework;
 
-      const kwargs = {
+      const modelKwargs = {
+        maxTokens: 500,
+        temperature: 0,
         ...modelInfo.framework.modelKwargs,
         ...options.endpointKwargs,
         ...options.modelKwargs,
       };
-      logger.debug('Resolved bedrock kwargs', { kwargs });
+      logger.debug('Resolved bedrock kwargs', { modelKwargs });
 
       this.llm = new Bedrock({
         verbose: options.verbose,
@@ -138,7 +141,8 @@ export class ChatEngineContext {
         model: modelId,
         region,
         endpointUrl,
-        ...kwargs,
+        ...modelKwargs,
+        modelKwargs: omitManagedBedrockKwargs(modelKwargs),
       });
     } else {
       // @ts-ignore

--- a/packages/galileo-sdk/src/utils/bedrock.ts
+++ b/packages/galileo-sdk/src/utils/bedrock.ts
@@ -1,0 +1,14 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+PDX-License-Identifier: Apache-2.0 */
+import { omit } from 'lodash';
+import { Dict } from '../models/types.js';
+
+/**
+ * Omit bedrock model kwargs that are managed by the bedrock langchain integration.
+ * @param kwargs
+ * @returns
+ */
+export function omitManagedBedrockKwargs(kwargs: Dict): Dict {
+  // https://github.com/langchain-ai/langchainjs/blob/005707e2e838c046227946f359e6c62ed2b3484b/langchain/src/util/bedrock.ts#L67
+  return omit(kwargs, ['maxTokens', 'temperature', 'stopSequences']);
+}

--- a/packages/galileo-sdk/test/README.md
+++ b/packages/galileo-sdk/test/README.md
@@ -1,0 +1,16 @@
+# Galileo SDK Testing
+
+## Unit Tests
+
+The unit tests are all run automatically during test, and build commands.
+
+Unit tests end with `.test.ts` or `.spec.ts`, and can be either located in this test folder
+or in the src folder to colocate.
+
+## Integ Tests
+
+Integration tests are not run automatically, and must be triggered locally with respective env setup against the integration points.
+
+Integration tests should end with `.integ.ts`, so they do not get treated as unit tests.
+
+See the `.vscode/launch.json` launcher for bedrock for example of testing integration tests.

--- a/packages/galileo-sdk/test/chat/bedrock.integ.ts
+++ b/packages/galileo-sdk/test/chat/bedrock.integ.ts
@@ -1,0 +1,170 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+PDX-License-Identifier: Apache-2.0 */
+// @ts-ignore
+import type {} from '@types/jest';
+import { TextEncoder } from 'util';
+import { InvokeEndpointCommand, InvokeEndpointCommandOutput, SageMakerRuntimeClient } from '@aws-sdk/client-sagemaker-runtime';
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+import { BatchWriteCommand, DynamoDBDocumentClient, PutCommand, QueryCommandOutput, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+
+import * as chatDDBLib from '../../src/chat/dynamodb/lib/index.js';
+import { ChatEngine, ChatEngineFromOption } from '../../src/chat/engine.js';
+import { ChatTurn } from '../../src/chat/memory.js';
+import { ModelFramework, FOUNDATION_MODEL_INVENTORY_SECRET, IFoundationModelInventory } from '../../src/models/index.js';
+
+// const dynamoDBMock = mockClient(DynamoDBClient);
+const dynamoDBDocumentMock = mockClient(DynamoDBDocumentClient);
+const secretsManagerMock = mockClient(SecretsManagerClient);
+const sageMakerRuntimeMock = mockClient(SageMakerRuntimeClient);
+
+describe('integ/bedrock', () => {
+  beforeAll(() => {
+    process.env.AWS_DEFAULT_REGION = 'us-east-1';
+    process.env[FOUNDATION_MODEL_INVENTORY_SECRET] = 'MOCK';
+  });
+
+  beforeEach(() => {
+    // dynamoDBMock.reset();
+    dynamoDBDocumentMock.reset();
+    secretsManagerMock.reset();
+    sageMakerRuntimeMock.reset();
+  });
+
+  test('query', async () => {
+    const userId = 'tester';
+    const chatId = 'test-chat';
+    const answer = 'LLM QA answer';
+
+    secretsManagerMock.on(GetSecretValueCommand).resolves({
+      SecretString: JSON.stringify({
+        defaultModelId: 'test',
+        models: {
+          test: {
+            uuid: 'test',
+            modelId: 'test',
+            framework: {
+              type: ModelFramework.BEDROCK,
+              modelId: 'anthropic.claude-v2',
+              region: 'us-east-1',
+              modelKwargs: {
+                max_tokens_to_sample: 300,
+                temperature: 0.5,
+                top_p: 0.5,
+              },
+            },
+            constraints: {
+              maxInputLength: 2048,
+              maxTotalTokens: 2048,
+            },
+            adapter: {
+              prompt: {
+                chat: {
+                  questionAnswer: {
+                    template: 'Human: <system>You are a research assistant in the \"{{domain}}\" domain. Based on the following rules contained in <rules> tags and provided corpus contained in <corpus> tags, answer the question. \n\n<rules>\n{{#each rules}}{{add @index 1}}. {{.}}\n{{/each}}\n</rules>\n\n</system>\n\n<corpus>\n{{context}}\n</corpus>\n\nQuestion: {{question}}\n\nAssistant: ',
+                  },
+                  condenseQuestion: {
+                    template: 'Human: <system>Given the following conversational dialog contained in <dialog> tags, and the \"Followup Question\" below, rephrase the \"Followup Question\" to be a concise standalone question in its original language. Without answering the question, return only the standalone question.\n</system>\n\n<dialog>\n{{#each chat_history}}\n{{~#if (eq type \"human\")}}User: {{content}}\n{{~else if (eq type \"ai\")}}You: {{content}}\n{{~else if (eq type \"system\")}}System: {{content}}\n{{~else}}{{#if type}}{{type}}: {{/if}}{{content}}\n{{/if}}\n\n{{/each}}\n</dialog>\n\nFollowup Question: {{question}}\n\nAssistant: ',
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as IFoundationModelInventory),
+    });
+
+    dynamoDBDocumentMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          userId,
+          chatId,
+          type: 'human',
+          data: {
+            content: 'Question 1?',
+          },
+        },
+        {
+          userId,
+          chatId,
+          type: 'ai',
+          data: {
+            content: 'Answer 1',
+          },
+        },
+      ] as chatDDBLib.DDBChatMessage[],
+      $metadata: {},
+    } as QueryCommandOutput);
+    dynamoDBDocumentMock.on(PutCommand).resolves({
+      Attributes: {},
+    });
+    dynamoDBDocumentMock.on(BatchWriteCommand).resolves({});
+    // combine inference
+    sageMakerRuntimeMock.on(InvokeEndpointCommand)
+      .resolvesOnce({
+        Body: new TextEncoder().encode(JSON.stringify([{
+          generated_text: 'LLM combine response',
+        }])),
+        $metadata: {},
+      } as InvokeEndpointCommandOutput)
+      .resolvesOnce({
+        Body: new TextEncoder().encode(JSON.stringify([{
+          generated_text: answer,
+        }])),
+        $metadata: {},
+      } as InvokeEndpointCommandOutput);
+
+    const options: ChatEngineFromOption = {
+      chatId: 'mock',
+      userId: 'tester',
+      domain: 'TestDomain',
+      chatHistoryTable: 'MockDatastore',
+      chatHistoryTableIndexName: 'MockIndex',
+      search: {
+        url: 'http://localhost:1337',
+        fetch: async (input, init): Promise<Response> => {
+
+          const content = JSON.stringify({
+            documents: [
+              {
+                pageContent: 'similar doc 1',
+                metadata: { a: 'a', b: "b'" },
+              },
+              {
+                pageContent: 'similar doc 2',
+                metadata: { a: 'a', b: "b'" },
+              },
+              {
+                pageContent: 'similar doc 3',
+                metadata: { a: 'a', b: "b'" },
+              },
+            ],
+          });
+
+          return new Response(content, {
+            status: 200,
+            headers: new Headers({
+              'Content-Type': 'application/json',
+            }),
+          });
+        },
+      },
+      verbose: true,
+    };
+
+    const engine = await ChatEngine.from(options);
+
+    expect(engine).toBeDefined();
+
+    const question = 'user question';
+    const result = await engine.query(question);
+    expect(result.question).toBe(question);
+    expect(result.answer).toBe(answer);
+    expect(result.turn).toEqual(expect.objectContaining({
+      ai: expect.anything(),
+      human: expect.anything(),
+      sources: expect.anything(),
+    } as ChatTurn));
+    expect(Array.isArray(result.turn.sources)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Lanchain integration has managed kwargs and allows passthrough kwargs, to support native model kwargs and managed kwargs we need to marshal how the kwargs to passed to bedrock integration.
