### PR TITLE
fix(infra): resolve no sagemaker models defined iam issue

### DIFF
--- a/demo/infra/src/application/ai/foundation-models/stack.ts
+++ b/demo/infra/src/application/ai/foundation-models/stack.ts
@@ -153,20 +153,15 @@ export class FoundationModelStack extends Stack {
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["sagemaker:InvokeEndpoint", "sagemaker:DescribeEndpoint"],
-        resources: Object.values(this.inventory.models)
-          .filter(
-            (modelInfo) =>
-              modelInfo.framework.type === ModelFramework.SAGEMAKER_ENDPOINT
-          )
-          .map((_modelInfo) => {
-            return Stack.of(this).formatArn({
-              service: "sagemaker",
-              resource: "endpoint",
-              // [Security] Unable to scope to endpoint name due to cross-environment without coupling stacks unnecessarily
-              resourceName: "*",
-              region: "*",
-            });
+        resources: [
+          Stack.of(this).formatArn({
+            service: "sagemaker",
+            resource: "endpoint",
+            // [Security] Unable to scope to endpoint name due to cross-environment without coupling stacks unnecessarily
+            resourceName: "*",
+            region: "*",
           }),
+        ],
       }),
     ];
 


### PR DESCRIPTION
## Description
Remove model based iam policy for sagemaker endpoints, since we can't scope to resource names it makes sense to just have single persistent policy anyways.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- Fixes #37 

## How Has This Been Tested?
- CDK Synth
