### PR TITLE
fix: increase pip installation timeout for docker image build

### DIFF
--- a/demo/corpus/Dockerfile
+++ b/demo/corpus/Dockerfile
@@ -57,7 +57,7 @@ RUN if [ -e "aws-lambda-rie" ]; then chmod +x aws-lambda-rie; mv aws-lambda-rie 
 # Install python deps
 WORKDIR ${EMBEDDINGS_DIR}
 COPY ./embeddings/dist ${EMBEDDINGS_DIR}/
-RUN pip install --target ${PYTHON_TARGET} ./corpus_embeddings-0.0.0-py3-none-any.whl
+RUN pip install --default-timeout=3000 --target ${PYTHON_TARGET} ./corpus_embeddings-0.0.0-py3-none-any.whl
 WORKDIR ${EMBEDDINGS_DIR}
 RUN tree -L 2 .
 


### PR DESCRIPTION
- was getting random timeout related build failures in local env

## Description

- default pip installation timeout was causing the corpus docker image build to fail non-deterministically on local development setup

## How Has This Been Tested?

- build, deployed, and tested in personal sandbox environment

* **What environment was this tested on?**

## PR Checklist
* [N/A] Have you added/updated documentation? N/A
* [N/A] Have you written new tests for your core changes, as applicable? 
* [X] Have you successfully ran build and tests with your changes locally?

**IMPORTANT:** Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
