### PR TITLE
fix(website): inference settings model/endpoint kwargs reset issue

### DIFF
--- a/demo/website/src/components/chat/dev-settings/ChatConfigForm/sections/InferenceSettings.tsx
+++ b/demo/website/src/components/chat/dev-settings/ChatConfigForm/sections/InferenceSettings.tsx
@@ -5,7 +5,7 @@ import { Icon } from '@cloudscape-design/components';
 import FormField from '@cloudscape-design/components/form-field';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { isEmpty } from 'lodash';
-import { FC, useCallback, useEffect } from 'react';
+import { FC, useCallback } from 'react';
 import { Updater } from 'use-immer';
 import { useFoundationModelInventory } from '../../../../../hooks/llm-inventory';
 import { useChatEngineConfigState } from '../../../../../providers/ChatEngineConfig';
@@ -38,17 +38,10 @@ export const InferenceSettings: FC = () => {
     }
   }, []);
 
-  // update default model/endpoint kwargs based on selected model
-  useEffect(() => {
-    const uuid = llmModel?.uuid as string | undefined;
-    if (inventory && uuid) {
-      const predefinedModel = inventory.models[uuid];
-      if (predefinedModel) {
-        setLlmModelKwargs(predefinedModel.framework.modelKwargs);
-        setLlmEndpointKwargs((predefinedModel.framework as ISageMakerEndpointModelFramework).endpointKwargs);
-      }
-    }
-  }, [inventory, llmModel?.uuid]);
+  const predefinedModel = llmModel?.uuid && inventory?.models ? inventory.models[llmModel.uuid] : undefined;
+  const modelKwargs = llmModelKwargs ?? predefinedModel?.framework.modelKwargs;
+  const endpointKwargs =
+    llmEndpointKwargs ?? (predefinedModel?.framework as ISageMakerEndpointModelFramework)?.endpointKwargs;
 
   const updateCustomModel: Updater<ICustomModel> = useCallback(
     (x) => {
@@ -84,7 +77,7 @@ export const InferenceSettings: FC = () => {
       <FormField label="Model Kwargs" stretch>
         <CodeEditor
           language="json"
-          value={toCodeEditorJson(llmModelKwargs)}
+          value={toCodeEditorJson(modelKwargs)}
           onChange={({ detail }) => {
             try {
               detail.value.length && setLlmModelKwargs(JSON.parse(detail.value));
@@ -97,7 +90,7 @@ export const InferenceSettings: FC = () => {
       <FormField label="Model Endpoint Kwargs" stretch>
         <CodeEditor
           language="json"
-          value={toCodeEditorJson(llmEndpointKwargs)}
+          value={toCodeEditorJson(endpointKwargs)}
           onChange={({ detail }) => {
             try {
               detail.value.length && setLlmEndpointKwargs(JSON.parse(detail.value));


### PR DESCRIPTION
## Description
Inference settings (modelKwargs, endpointKwargs) were reset every time the `Inference` tab was selected in chat settings.

**Does this PR introduce a breaking change?**  
_(What changes might users need to make in their application due to this PR?)_
NO

## Related Issues/Discussion
NA

## How Has This Been Tested?
Local

* **What environment was this tested on?**
Local

## Screenshots (if appropriate)
NA

## PR Checklist

* [ ] Have you added/updated documentation?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran build and tests with your changes locally?

**IMPORTANT:** Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
