### PR TITLE
fix(docs): restore missing Cloud9 quick-start instructions

### DIFF
--- a/docs/content/overview/quick-start/index.md
+++ b/docs/content/overview/quick-start/index.md
@@ -6,12 +6,12 @@
 
 |   Tool                |   Version   |    Recommendation            |
 | --------------------- | ----------- | ---------------------------- |
-| pnpm                  | >=8.x       | https://pnpm.io/installation |
+| pnpm                  | >=8.x       | <https://pnpm.io/installation> |
 | NodeJS                | >=18        | Use Node Version Manager ([nvm](https://github.com/nvm-sh/nvm)) |
 | Python                | >=3.10,<4   | Use Python Version Manager ([pyenv](https://github.com/pyenv/pyenv)) |
-| Poetry                | >=1.5,<2    | https://python-poetry.org/docs/ |
-| AWS CLI               | v2          | https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html |
-| Docker[^1] | v20+     | https://docs.docker.com/desktop/ |
+| Poetry                | >=1.5,<2    | <https://python-poetry.org/docs/> |
+| AWS CLI               | v2          | <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html> |
+| Docker[^1] | v20+     | <https://docs.docker.com/desktop/> |
 | JDK                   | v17+        | [Amazon Corretto 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html) |
 
 [^1]: Docker virtual disk space should have at least 30GB of free space. If you see `no space left on device` error during build, free up space by running `docker system prune -f` and/or increasing the virtual disk size.
@@ -32,7 +32,6 @@ For predefined models, check the instance type from the follow table to determin
 
 Example, if you only deploy the *Falcon Lite* predefined model, then you only need to ensure `ml.g5.12xlarge for endpoint usage >= 1`, while the other quotas of *X for endpoint usage* can remain 0. With the exception of below minimum requirements.
 
-
 !!! tip "Cross-Region Deployments"
     Galileo CLI enables you to deploy your LLM stack and application stack into different regions.
 
@@ -49,10 +48,10 @@ Quickly deploy the full solution using the following:
 > * Make sure your AWS credentials are setup and available in the shell.
 
 ### CLI
+
 !!! tip "Recommended basic development for individuals, developer account, trials, and demos"
 
 Use the companion cli for deploying the cdk infra
-
 
 ```sh
 pnpm install
@@ -65,6 +64,7 @@ The cli will generate an application configuration file in demo/infra/config.jso
 > `pnpm run galileo-cli --help` for cli help info
 
 ### Manually
+
 !!! tip "Recommended for full control and modification"
 
 ```sh
@@ -77,6 +77,7 @@ pnpm exec cdk deploy --app cdk.out --require-approval never Dev/Galileo-SampleDa
 ```
 
 ### CI/CD pipeline
+
 !!! tip "Recommended for live services and for shared team accounts"
 
 1. Create a CodeCommit repository in your target account/region name "galileo"
@@ -88,3 +89,33 @@ pnpm exec cdk deploy --app cdk.out --require-approval never Dev/Galileo-SampleDa
 ## What is deployed?
 
 ![](../../assets/images/galileo-arch.png)
+
+---
+
+## Using Cloud9 as your Galileo Development Environment
+
+In your Galileo development account:
+
+* Cloud9 → Create Environment
+* New EC2 Instance → m5.large + Ubuntu 22.04 + 4h Timeout + AWS Systems Manager
+* Open Cloud 9 IDE for this new environment
+* Follow the resize instructions at <https://ec2spotworkshops.com/ecs-spot-capacity-providers/workshopsetup/resize_ebs.html>, giving your instance EBS volume 300GB (followed by a reboot)
+
+In the Cloud9 instance shell, install some prerequisites:
+
+```bash
+sudo apt update && sudo apt upgrade -y
+nvm install lts/iron
+nvm use lts/iron
+npm i -g pnpm
+wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add -
+sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+sudo apt-get update; sudo apt-get install -y java-18-amazon-corretto-jdk
+
+sudo apt install -y python3.11
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 110
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 100
+# NOTE: select python3.11 from the list
+sudo update-alternatives --config python3
+curl -sSL https://install.python-poetry.org | python3 -
+```


### PR DESCRIPTION
- There used to be instructions in the default README explaining how to use Cloud9 for sandbox deployments, and these were accidentally deleted by me in recent the mkdocs refactor

## How Has This Been Tested?

Documentation changes built and tested

## PR Checklist

* [X] Have you added/updated documentation?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran build and tests with your changes locally?

**IMPORTANT:** Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
