### PR TITLE
fix: Reset Vector Execution Flow

### DIFF
--- a/demo/infra/src/application/corpus/pipeline/index.ts
+++ b/demo/infra/src/application/corpus/pipeline/index.ts
@@ -183,7 +183,7 @@ export class IndexingPipeline extends Construct {
     });
 
     props.inputBucket.grantRead(configLambda);
-    props.cacheTable.grantReadData(configLambda);
+    props.cacheTable.grantReadWriteData(configLambda);
     stagingBucket.grantReadWrite(configLambda);
 
     const configTask = new tasks.LambdaInvoke(this, 'ConfigTask', {

--- a/packages/galileo-sdk/src/vectorstores/pgvector/index.ts
+++ b/packages/galileo-sdk/src/vectorstores/pgvector/index.ts
@@ -445,7 +445,7 @@ export class PGVectorStore extends VectorStore {
    */
   async truncate(task?: pg.ITask<any>): Promise<void> {
     if (await this.tableExists(task)) {
-      await (task || this.db).query('TRUNCATE $1', [this.tableName]);
+      await (task || this.db).query(`TRUNCATE ${this.tableName}`);
     }
   }
 


### PR DESCRIPTION
## Description
- Add DynamoDB Write Table Permission
- Change from parameterized query to interpolation to avoid single quote in TRUNCATE statement (which is invalid syntax).

**Does this PR introduce a breaking change?**  
- No

## Related Issues/Discussion
https://github.com/aws-samples/aws-genai-conversational-rag-reference/issues/107

## How Has This Been Tested?

Test by calling:
```
{
  "VectorStoreManagement": {
    "PurgeData": true,
    "CreateIndexes": false
  }
}
```

* **What environment was this tested on?**
```
system: Linux 6.2.0-1018-aws #18~22.04.1-Ubuntu SMP Wed Jan 10 22:54:16 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
pnpm: 8.12.1 
node: v20.10.0 
python: Python 3.10.12 
poetry: Poetry (version 1.7.1) 
docker: Docker version 24.0.7, build afdd53b 
java: openjdk 18.0.2 2022-07-19
OpenJDK Runtime Environment Corretto-18.0.2.9.1 (build 18.0.2+9-FR)
OpenJDK 64-Bit Server VM Corretto-18.0.2.9.1 (build 18.0.2+9-FR, mixed mode, sharing) 
aws: aws-cli/2.15.2 Python/3.11.6 Linux/6.2.0-1018-aws exe/x86_64.ubuntu.22 prompt/off
```

## Screenshots (if appropriate)
n/a

## PR Checklist

* [x] Have you added/updated documentation?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran build and tests with your changes locally?

**IMPORTANT:** Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
