### PR TITLE
fix: Add missing parameter to Reset Vector Store Execution Flow

### DIFF
--- a/docs/content/development/vector-store/index.md
+++ b/docs/content/development/vector-store/index.md
@@ -171,6 +171,7 @@ The state machine can be executed with the following payload to delete the datab
 {
   "VectorStoreManagement": {
     "PurgeData": true,
+    "CreateIndexes": false
   }
 }
 ```


### PR DESCRIPTION
## Description
Adding an extra parameter needed in the samples in documentation for the execution to work 

**Does this PR introduce a breaking change?**  
No.

## Related Issues/Discussion
https://github.com/aws-samples/aws-genai-conversational-rag-reference/issues/107

## How Has This Been Tested?
Calling Step Function with:
```
{
  "VectorStoreManagement": {
    "PurgeData": true,
    "CreateIndexes": false
  }
}
```
will cause the execution to fail with:
```
Invalid path '$.VectorStoreManagement.CreateIndexes': The choice state's condition path references an invalid value.
```

* **What environment was this tested on?**
```
system: Linux 6.2.0-1018-aws #18~22.04.1-Ubuntu SMP Wed Jan 10 22:54:16 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
pnpm: 8.12.1 
node: v20.10.0 
python: Python 3.10.12 
poetry: Poetry (version 1.7.1) 
docker: Docker version 24.0.7, build afdd53b 
java: openjdk 18.0.2 2022-07-19
OpenJDK Runtime Environment Corretto-18.0.2.9.1 (build 18.0.2+9-FR)
OpenJDK 64-Bit Server VM Corretto-18.0.2.9.1 (build 18.0.2+9-FR, mixed mode, sharing) 
aws: aws-cli/2.15.2 Python/3.11.6 Linux/6.2.0-1018-aws exe/x86_64.ubuntu.22 prompt/off
```
## PR Checklist

* [x] Have you added/updated documentation?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran build and tests with your changes locally?

**IMPORTANT:** Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
