### PR TITLE
chore: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/upgrade-mainline.yml
+++ b/.github/workflows/upgrade-mainline.yml
@@ -26,7 +26,7 @@ jobs:
         name: Find mutations
         run: |-
           git add .
-          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=patch_created::true"
+          git diff --staged --patch --exit-code > .repo.patch || echo "patch_created=true" >> "$GITHUB_OUTPUT"
       - if: steps.create_patch.outputs.patch_created
         name: Upload patch
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter