### PR TITLE
chore: update docs to enforce usage of pnpm v8

### DIFF
--- a/docs/content/overview/quick-start/index.md
+++ b/docs/content/overview/quick-start/index.md
@@ -6,7 +6,7 @@
 
 |   Tool                |   Version   |    Recommendation            |
 | --------------------- | ----------- | ---------------------------- |
-| pnpm                  | >=8.x       | <https://pnpm.io/installation> |
+| pnpm                  | >=8 <9      | <https://pnpm.io/installation> |
 | NodeJS                | >=18        | Use Node Version Manager ([nvm](https://github.com/nvm-sh/nvm)) |
 | Python                | >=3.10,<4   | Use Python Version Manager ([pyenv](https://github.com/pyenv/pyenv)) |
 | Poetry                | >=1.5,<2    | <https://python-poetry.org/docs/> |

--- a/prerequisite-check.sh
+++ b/prerequisite-check.sh
@@ -56,7 +56,7 @@ check() {
   return 0
 }
 
-check "pnpm" "pnpm --version" ">=8" \
+check "pnpm" "pnpm --version" ">=8 <9" \
   "Recommendation: Install PNPM 8.6+. See https://pnpm.io/installation"
 PNPM_PASS=$?
 


### PR DESCRIPTION
## Description
pnpm 9 introduces a breaking change where pnpm-lock file will be updated to version 9 and newest dependencies will be installed when running `pnpm install`. This causes `pnpm build` failed. This PR is to update docs to inform usage of pnpm version 8. 

**Does this PR introduce a breaking change?**  
No

## Related Issues/Discussion
Newest of [PDK Change](https://github.com/aws/aws-pdk/pull/782/files) will update the engine field in the package.json. However, it requires the updates of other dependencies and an overall package. Will do in another PR. 

## How Has This Been Tested?
Yes

* **What environment was this tested on?**
Both pnpm version 9 and version 8 to ensure `./prerequisite-check.sh` working as expected

## Screenshots (if appropriate)

## PR Checklist

* [x] Have you added/updated documentation?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran build and tests with your changes locally?

**IMPORTANT:** Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
